### PR TITLE
Fix pydantic settings and add simple frontend

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, Query, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from typing import List, Dict, Optional
 from pathlib import Path
@@ -46,6 +47,9 @@ app.add_middleware(
     allow_origins=["*"], allow_credentials=True,
     allow_methods=["*"], allow_headers=["*"],
 )
+
+# serve simple frontend
+app.mount("/ui", StaticFiles(directory="frontend", html=True), name="ui")
 
 EXPORTS_DIR = Path("exports"); EXPORTS_DIR.mkdir(exist_ok=True)
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,5 @@
-from pydantic import BaseSettings, Field
+from pydantic import Field
+from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     app_name: str = Field(default="EasyIntern")

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>EasyIntern UI</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    textarea { width: 100%; }
+    pre { background: #f0f0f0; padding: 1em; }
+  </style>
+</head>
+<body>
+  <h1>EasyIntern</h1>
+  <p>Enter a candidate profile JSON and fetch ranked opportunities.</p>
+  <textarea id="profile" rows="8">{
+  "name": "Student",
+  "skills": ["python", "fastapi"],
+  "interests": ["backend", "web"]
+}</textarea>
+  <br/>
+  <button id="rankBtn">Get Rankings</button>
+  <pre id="results"></pre>
+  <script>
+    document.getElementById('rankBtn').onclick = async () => {
+      const profileText = document.getElementById('profile').value;
+      let profile;
+      try {
+        profile = JSON.parse(profileText);
+      } catch (e) {
+        alert('Invalid JSON');
+        return;
+      }
+      const resp = await fetch('/rank?limit=20', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(profile)
+      });
+      const data = await resp.json();
+      document.getElementById('results').textContent = JSON.stringify(data, null, 2);
+    };
+  </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,7 @@ fastapi
 uvicorn
 httpx
 pydantic
+pydantic-settings
 SQLAlchemy
 beautifulsoup4
+feedparser


### PR DESCRIPTION
## Summary
- migrate Settings to use pydantic-settings for compatibility with Pydantic v2
- serve a minimal static web UI and mount it at `/ui`
- document new dependencies and include feedparser

## Testing
- `python -m app.cli --help`
- `python -m uvicorn app.api:app --help`
- `python - <<'PY'\nfrom fastapi.testclient import TestClient\nfrom app.api import app\nwith TestClient(app) as client:\n    r = client.get('/ui/')\n    print('status', r.status_code)\n    print('body_start', r.text[:60])\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68c457d9dbb8832dadbb06d6b0020f95