### PR TITLE
Add anti-bot fallback for Indeed scraper

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -8,8 +8,16 @@ def _load_json(p): return json.loads(Path(p).read_text(encoding="utf-8"))
 
 def cmd_scrape(args):
     cfg = _load_json(args.config)
-    n = asyncio.run(scrape_and_store(cfg))
-    print(f"Inserted {n} new opportunities.")
+    result = asyncio.run(scrape_and_store(cfg))
+    if isinstance(result, dict):
+        inserted = result.get("inserted")
+        fetched = result.get("fetched")
+        if fetched is not None:
+            print(f"Inserted {inserted} new opportunities (fetched {fetched}).")
+        else:
+            print(f"Inserted {inserted} new opportunities.")
+    else:
+        print(f"Inserted {result} new opportunities.")
 
 def cmd_rank(args):
     prof = _load_json(args.profile)

--- a/app/config.py
+++ b/app/config.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
     enable_greenhouse: bool = Field(default=True)
     enable_lever: bool = Field(default=True)
     enable_rss: bool = Field(default=True)
+    indeed_proxy_url: str | None = Field(default=None)
 
     class Config:
         env_file = ".env"

--- a/app/scrapers/indeed.py
+++ b/app/scrapers/indeed.py
@@ -1,8 +1,15 @@
-import httpx, re
+import asyncio
+import logging
 from datetime import datetime, timezone
+
+import cloudscraper
 from bs4 import BeautifulSoup
+from cloudscraper.exceptions import CloudflareChallengeError
+
 from ..models import Opportunity
 from ..config import settings
+
+logger = logging.getLogger(__name__)
 
 class IndeedScraper:
     """
@@ -14,17 +21,52 @@ class IndeedScraper:
         self.location = location
         self.max_pages = max_pages
         self.base_url = "https://ca.indeed.com/jobs"
+        self._proxy_url = settings.indeed_proxy_url
+        self._scraper = self._build_scraper()
 
-    async def fetch_page(self, client, start):
+    def _build_scraper(self):
+        scraper = cloudscraper.create_scraper(
+            browser={"browser": "chrome", "platform": "windows", "mobile": False},
+        )
+        scraper.headers.update(
+            {
+                "User-Agent": settings.user_agent,
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+                "Accept-Language": "en-US,en;q=0.9",
+                "Cache-Control": "no-cache",
+                "Pragma": "no-cache",
+                "Referer": "https://ca.indeed.com/",
+            }
+        )
+        if self._proxy_url:
+            scraper.proxies = {"http": self._proxy_url, "https": self._proxy_url}
+        return scraper
+
+    async def fetch_page(self, start):
         params = {"q": self.query, "l": self.location, "start": start}
         try:
-            r = await client.get(self.base_url, params=params, headers={"User-Agent": settings.user_agent}, timeout=15)
-            if r.status_code != 200:
-                return []
-        except Exception:
+            response = await asyncio.to_thread(
+                self._scraper.get,
+                self.base_url,
+                params=params,
+                timeout=settings.http_timeout_seconds,
+            )
+        except CloudflareChallengeError as exc:
+            logger.warning("Indeed request blocked by Cloudflare challenge: %s", exc)
+            return []
+        except Exception as exc:
+            logger.exception("Indeed request failed: %s", exc)
             return []
 
-        soup = BeautifulSoup(r.text, "html.parser")
+        if response.status_code != 200:
+            logger.warning("Indeed request returned status %s", response.status_code)
+            return []
+
+        if self._is_blocked_html(response.text):
+            logger.warning("Indeed responded with a block page; configure a proxy/anti-bot service for access")
+            return []
+
+        soup = BeautifulSoup(response.text, "html.parser")
         jobs = []
         for card in soup.select("div.job_seen_beacon"):
             title_el = card.select_one("h2 a")
@@ -57,7 +99,14 @@ class IndeedScraper:
 
     async def fetch(self):
         opps = []
-        async with httpx.AsyncClient() as client:
-            for p in range(self.max_pages):
-                opps.extend(await self.fetch_page(client, p * 10))
+        for p in range(self.max_pages):
+            opps.extend(await self.fetch_page(p * 10))
         return opps
+
+    def _is_blocked_html(self, html: str) -> bool:
+        block_tokens = [
+            "Blocked - Indeed.com",
+            "Our systems have detected unusual traffic",
+            "cf-mitigated",
+        ]
+        return any(token in html for token in block_tokens)

--- a/app/scrapers/rss.py
+++ b/app/scrapers/rss.py
@@ -56,7 +56,7 @@ class RSSScraper:
         if not self.feeds:
             return []
         opps = []
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(follow_redirects=True) as client:
             for name, url in self.feeds.items():
                 part = await self.fetch_feed(client, name, url)
                 opps.extend(part)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pydantic-settings
 SQLAlchemy
 beautifulsoup4
 feedparser
+cloudscraper


### PR DESCRIPTION
## Summary
- switch the Indeed scraper to a Cloudflare-aware cloudscraper client with explicit block detection and logging
- allow the scraper to optionally route through a configured proxy URL for third-party anti-bot services
- add the cloudscraper dependency so the new client is available in all environments

## Testing
- pip install -r requirements.txt
- python -m app.cli scrape --config scrape_config.json


------
https://chatgpt.com/codex/tasks/task_e_68c9ecc8268c832d87148c292a4ae18b